### PR TITLE
Fix httpx dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "Retell", email = "support@retellai.com" },
 ]
 dependencies = [
-    "httpx>=0.23.0, <1",
+    "httpx>=0.23.0, <0.28.0",
     "pydantic>=1.9.0, <3",
     "typing-extensions>=4.7, <5",
     "anyio>=3.5.0, <5",


### PR DESCRIPTION
httpx 0.28.0 has a breaking change. It removes support for `proxies` keyword in constructor of class SyncAPIClient leading to failure of instantiation of `class Retell`