### PR TITLE
fix webhook_auth symmetric signature

### DIFF
--- a/src/retell/lib/webhook_auth.py
+++ b/src/retell/lib/webhook_auth.py
@@ -40,7 +40,9 @@ def make_secure_webhooks(get_signer, get_verifier):  # type: ignore
 
 def symmetric_get_signer(secret):  # type: ignore
     def signer(input_str):  # type: ignore
-        return hashlib.sha256(secret.encode() + input_str.encode()).hexdigest()  # type: ignore
+        h = hmac.new(secret.encode(), digestmod=hashlib.sha256) # type: ignore
+        h.update(input_str.encode()) # type: ignore
+        return h.hexdigest() # type: ignore
 
     return signer  # type: ignore
 

--- a/tests/webhook_auth.py
+++ b/tests/webhook_auth.py
@@ -1,0 +1,14 @@
+import json
+from retell.lib.webhook_auth import symmetric
+
+
+def test_symmetric_signature() -> None:
+    post_data = {
+        "name": "some_function_name",
+        "args": {"some_arg": "ABC123"},
+    }
+    body = json.dumps(post_data, separators=(",", ":"), ensure_ascii=False)
+    api_key = "fake-api-key"
+
+    signature = symmetric["sign"](body, api_key)
+    assert symmetric["verify"](body, api_key, signature)


### PR DESCRIPTION
the hmac library is used to verify and should also be used to sign