### PR TITLE
chore: disable stlc auto-merge workflow

### DIFF
--- a/.github/workflows/stlc-auto-merge.yml
+++ b/.github/workflows/stlc-auto-merge.yml
@@ -1,12 +1,6 @@
 name: Auto-merge SDK release PRs
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
-  workflow_run:
-    workflows: ['CI', 'Release Doctor']
-    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Summary

Disable automatic triggers for the stlc auto-merge workflow while we finish validating the migration pipeline.

The workflow is still available via manual `workflow_dispatch`, but it will no longer run automatically on PR updates or completed CI runs.

## Test plan

- Parsed `.github/workflows/stlc-auto-merge.yml` locally with Ruby YAML loader.