### PR TITLE
chore: restore stlc auto-merge triggers

### DIFF
--- a/.github/workflows/stlc-auto-merge.yml
+++ b/.github/workflows/stlc-auto-merge.yml
@@ -1,6 +1,12 @@
 name: Auto-merge SDK release PRs
 
 on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+  workflow_run:
+    workflows: ['CI', 'Release Doctor']
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Summary

Restore automatic triggers for the stlc auto-merge workflow now that we are ready to validate the stlc migration pipeline.

This keeps the existing PR qualification logic, same-repository guard, check/status validation, and `--match-head-commit` protection unchanged.

## Test plan

- Parsed `.github/workflows/stlc-auto-merge.yml` locally with Ruby YAML loader.